### PR TITLE
Send Enter after "exit"

### DIFF
--- a/SharpRDP/SharpRDP/Client.cs
+++ b/SharpRDP/SharpRDP/Client.cs
@@ -154,6 +154,10 @@ namespace SharpRDP
 
                 Thread.Sleep(500);
                 SendText("exit");
+
+                SendElement(enterdown);
+                Thread.Sleep(500);
+                SendElement(enterup);
             }
             else if (execwith == "powershell" || execwith == "ps")
             {
@@ -176,6 +180,10 @@ namespace SharpRDP
 
                 Thread.Sleep(500);
                 SendText("exit");
+
+                SendElement(enterdown);
+                Thread.Sleep(500);
+                SendElement(enterup);
             }
             else
             {


### PR DESCRIPTION
ShardRDP did not send Enter after "exit". The PowerShell and Command Prompt windows were left open.